### PR TITLE
Enhance diagnostics with chatId and stabilize toggle persistence

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -462,6 +462,7 @@ export async function POST(request: NextRequest) {
       const diagnosticsContext = await buildDiagnosticsContext({
         userId,
         anonymousId: anonymousSession?.id ?? null,
+        chatId,
       });
 
       const stream = createUIMessageStream<ChatMessage>({
@@ -507,6 +508,7 @@ export async function POST(request: NextRequest) {
                 (part) => part.type === 'file',
               ),
               lastGeneratedImage,
+              chatId,
             }),
             onError: (error) => {
               log.error({ error }, 'streamText error');

--- a/app/api/diagnostics/client/route.ts
+++ b/app/api/diagnostics/client/route.ts
@@ -32,6 +32,7 @@ if (process.env.REDIS_URL) {
 }
 
 const ClientDiagnosticsInput = z.object({
+  chatId: z.string(),
   consent: z.boolean().default(false),
   data: z.object({
     userAgent: z.string().default(''),
@@ -104,7 +105,8 @@ export async function POST(request: NextRequest) {
       anonymous = await createAnonymousSession();
       if (anonymous) await setAnonymousSession(anonymous);
     }
-    const sessionKey = getSessionKeyForIds({ userId, anonymousId: anonymous?.id });
+    const chatId = parsed.data.chatId;
+    const sessionKey = getSessionKeyForIds({ userId, anonymousId: anonymous?.id, chatId });
 
     const { userAgent, platform } = parsed.data.data;
     const family = detectOS(userAgent || '', platform);
@@ -118,7 +120,7 @@ export async function POST(request: NextRequest) {
       },
     };
 
-    setClientDiagnostics(sessionKey, payload);
+    await setClientDiagnostics(sessionKey, payload);
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/app/api/diagnostics/network/route.ts
+++ b/app/api/diagnostics/network/route.ts
@@ -31,6 +31,7 @@ if (process.env.REDIS_URL) {
 }
 
 const NetworkInput = z.object({
+  chatId: z.string(),
   targets: z.array(z.string().url()).default([
     'https://vercel.com',
     'https://www.google.com/generate_204',
@@ -86,7 +87,8 @@ export async function POST(request: NextRequest) {
       anonymous = await createAnonymousSession();
       if (anonymous) await setAnonymousSession(anonymous);
     }
-    const sessionKey = getSessionKeyForIds({ userId, anonymousId: anonymous?.id });
+    const chatId = parsed.data.chatId;
+    const sessionKey = getSessionKeyForIds({ userId, anonymousId: anonymous?.id, chatId });
 
     const results = await Promise.all(
       parsed.data.targets.map((t) => checkTarget(t)),
@@ -97,7 +99,7 @@ export async function POST(request: NextRequest) {
       results,
     };
 
-    setNetworkDiagnostics(sessionKey, payload);
+    await setNetworkDiagnostics(sessionKey, payload);
 
     return NextResponse.json({ ok: true, results });
   } catch (error) {

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -153,7 +153,7 @@ function PureChatHeader({
           </Tooltip>
         )}
       </div>
-      <CollectClientDiagnostics open={diagOpen} onOpenChange={setDiagOpen} />
+  <CollectClientDiagnostics open={diagOpen} onOpenChange={setDiagOpen} chatId={chatId} />
     </header>
   );
 }

--- a/components/ohfixit/collect-client-diagnostics.tsx
+++ b/components/ohfixit/collect-client-diagnostics.tsx
@@ -11,7 +11,21 @@ type Props = {
   chatId: string;
 };
 
-function collectSnapshot() {
+async function quickPing(url: string, timeoutMs = 2500) {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    const t0 = performance.now();
+    const res = await fetch(url, { cache: 'no-store', signal: ctrl.signal });
+    const dt = performance.now() - t0;
+    clearTimeout(t);
+    return { ok: res.ok, rtt: Math.round(dt) };
+  } catch {
+    return { ok: false, rtt: undefined as number | undefined };
+  }
+}
+
+async function collectSnapshot() {
   try {
     const nav = navigator as any;
     const connection = nav?.connection || nav?.mozConnection || nav?.webkitConnection;
@@ -29,6 +43,9 @@ function collectSnapshot() {
       saveData: connection.saveData,
     } : undefined;
 
+    // try a very fast ping to a lightweight endpoint
+    const ping = await quickPing('https://www.google.com/generate_204');
+
     return {
       consent: true,
       data: {
@@ -39,7 +56,10 @@ function collectSnapshot() {
         timeZone,
         screen: screenInfo,
         device,
-        network,
+        network: {
+          ...network,
+          rtt: typeof ping.rtt === 'number' ? ping.rtt : network?.rtt,
+        },
         window: typeof window !== 'undefined' ? { innerWidth: window.innerWidth, innerHeight: window.innerHeight } : undefined,
       },
     };
@@ -53,13 +73,15 @@ export function CollectClientDiagnostics({ open, onOpenChange, chatId }: Props) 
   const [preview, setPreview] = useState<any | null>(null);
 
   useEffect(() => {
-    if (open) setPreview(collectSnapshot());
+    if (open) {
+      collectSnapshot().then(setPreview).catch(() => setPreview(null));
+    }
   }, [open]);
 
   const handleAccept = useCallback(async () => {
     setSubmitting(true);
     try {
-      const payload = { ...collectSnapshot(), chatId };
+  const payload = { ...(await collectSnapshot()), chatId };
       const res = await fetch('/api/diagnostics/client', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/components/ohfixit/collect-client-diagnostics.tsx
+++ b/components/ohfixit/collect-client-diagnostics.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  chatId: string;
 };
 
 function collectSnapshot() {
@@ -47,7 +48,7 @@ function collectSnapshot() {
   }
 }
 
-export function CollectClientDiagnostics({ open, onOpenChange }: Props) {
+export function CollectClientDiagnostics({ open, onOpenChange, chatId }: Props) {
   const [submitting, setSubmitting] = useState(false);
   const [preview, setPreview] = useState<any | null>(null);
 
@@ -58,7 +59,7 @@ export function CollectClientDiagnostics({ open, onOpenChange }: Props) {
   const handleAccept = useCallback(async () => {
     setSubmitting(true);
     try {
-      const payload = collectSnapshot();
+      const payload = { ...collectSnapshot(), chatId };
       const res = await fetch('/api/diagnostics/client', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -75,7 +76,7 @@ export function CollectClientDiagnostics({ open, onOpenChange }: Props) {
     } finally {
       setSubmitting(false);
     }
-  }, [onOpenChange]);
+  }, [onOpenChange, chatId]);
 
   const redactUA = useMemo(() => {
     const ua = preview?.data?.userAgent as string | undefined;

--- a/lib/ai/tools/ohfixit/client-env.ts
+++ b/lib/ai/tools/ohfixit/client-env.ts
@@ -3,8 +3,7 @@ import 'server-only';
 import { tool, type Tool } from 'ai';
 import { z } from 'zod';
 import {
-  getRecord,
-  getSessionKeyForIds,
+  getRecordByChat,
   type ClientDiagnostics,
 } from '@/lib/ohfixit/diagnostics-store';
 import { capabilityMap, detectOS } from '@/lib/ohfixit/os-capabilities';
@@ -21,9 +20,11 @@ export type ClientEnvOutput = {
 export function createClientEnvTool({
   userId,
   anonymousId,
+  chatId,
 }: {
   userId?: string | null;
   anonymousId?: string | null;
+  chatId: string;
 }): Tool<z.infer<typeof ClientEnvInput>, ClientEnvOutput> {
   return tool({
     description:
@@ -44,11 +45,11 @@ export function createClientEnvTool({
           resolvedAnonymousId = anon?.id || null;
         } catch {}
       }
-      const sessionKey = getSessionKeyForIds({
+      const rec = await getRecordByChat({
+        chatId,
         userId: resolvedUserId,
         anonymousId: resolvedAnonymousId,
       });
-      const rec = getRecord(sessionKey);
       if (!rec?.client || rec.client.consent !== true) {
         return {};
       }

--- a/lib/ai/tools/tools.ts
+++ b/lib/ai/tools/tools.ts
@@ -27,6 +27,7 @@ export function getTools({
   attachments = [],
   lastGeneratedImage = null,
   contextForLLM,
+  chatId,
 }: {
   dataStream: StreamWriter;
   session: Session;
@@ -35,15 +36,16 @@ export function getTools({
   attachments: Array<FileUIPart>;
   lastGeneratedImage: { imageUrl: string; name: string } | null;
   contextForLLM: ModelMessage[];
+  chatId: string;
 }) {
   const anonymousIdPromise = getAnonymousSession().then((s) => s?.id || null).catch(() => null);
   return {
     getWeather,
     guideSteps,
     automation,
-    // OhFixIt diagnostics tools
-    clientEnv: createClientEnvTool({ userId: session?.user?.id, anonymousId: undefined }),
-    networkCheck: createNetworkCheckTool({ userId: session?.user?.id, anonymousId: undefined }),
+  // OhFixIt diagnostics tools
+  clientEnv: createClientEnvTool({ userId: session?.user?.id, anonymousId: undefined, chatId }),
+  networkCheck: createNetworkCheckTool({ userId: session?.user?.id, anonymousId: undefined, chatId }),
     createDocument: createDocumentTool({
       session,
       dataStream,

--- a/lib/ohfixit/diagnostics-context.ts
+++ b/lib/ohfixit/diagnostics-context.ts
@@ -6,6 +6,7 @@ import { capabilityMap, detectOS } from '@/lib/ohfixit/os-capabilities';
 export type DiagnosticsContextOptions = {
   userId?: string | null;
   anonymousId?: string | null;
+  chatId: string;
   includeTips?: boolean;
 };
 
@@ -19,14 +20,11 @@ function safeJoin(items: Array<string | undefined | null>, sep = ', ') {
 }
 
 export async function buildDiagnosticsContext(
-  opts: DiagnosticsContextOptions,
+  opts: DiagnosticsContextOptions
 ): Promise<string | null> {
-  const sessionKey = getSessionKeyForIds({
-    userId: opts.userId ?? null,
-    anonymousId: opts.anonymousId ?? null,
-  });
-
-  const rec = getRecord(sessionKey);
+  const { userId, anonymousId, chatId } = opts;
+  const { getRecordByChat } = await import('./diagnostics-store');
+  const rec = await getRecordByChat({ userId, anonymousId, chatId });
   if (!rec) return null;
 
   const parts: string[] = [];

--- a/lib/ohfixit/diagnostics-context.ts
+++ b/lib/ohfixit/diagnostics-context.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { getRecord, getSessionKeyForIds } from '@/lib/ohfixit/diagnostics-store';
+// DB-backed diagnostics retrieval happens via getRecordByChat (dynamic import below)
 import { capabilityMap, detectOS } from '@/lib/ohfixit/os-capabilities';
 
 export type DiagnosticsContextOptions = {

--- a/tests/unit/diagnostics-context.test.ts
+++ b/tests/unit/diagnostics-context.test.ts
@@ -4,19 +4,20 @@ import buildDiagnosticsContext from '@/lib/ohfixit/diagnostics-context';
 
 describe('buildDiagnosticsContext', () => {
   const userId = 'user-123';
-  const sessionKey = getSessionKeyForIds({ userId, anonymousId: null });
+  const chatId = 'test-chat-ctx';
+  const sessionKey = { userId, anonymousId: null, chatId };
 
   beforeEach(() => {
-    // no reset needed; keys are unique per test as userId constant
+    // no reset needed; keys are unique per test as userId+chatId constant
   });
 
   it('returns null when no diagnostics exist', async () => {
-    const text = await buildDiagnosticsContext({ userId, anonymousId: null });
+    const text = await buildDiagnosticsContext({ userId, anonymousId: null, chatId });
     expect(text === null || typeof text === 'string').toBe(true);
   });
 
   it('includes OS, capabilities, client snapshot and network checks', async () => {
-    setClientDiagnostics(sessionKey, {
+    await setClientDiagnostics(sessionKey, {
       collectedAt: Date.now(),
       consent: true,
       data: {
@@ -33,7 +34,7 @@ describe('buildDiagnosticsContext', () => {
       },
     });
 
-    setNetworkDiagnostics(sessionKey, {
+    await setNetworkDiagnostics(sessionKey, {
       ranAt: Date.now(),
       results: [
         { target: 'https://example.com/ping', ok: true, status: 200, latencyMs: 120 },
@@ -41,7 +42,7 @@ describe('buildDiagnosticsContext', () => {
       ],
     });
 
-    const text = await buildDiagnosticsContext({ userId, anonymousId: null });
+    const text = await buildDiagnosticsContext({ userId, anonymousId: null, chatId });
     expect(text).toBeTruthy();
     const s = text as string;
     expect(s).toContain('OS: macOS');


### PR DESCRIPTION
Integrate chatId into diagnostics context and tools, improving client and network diagnostics handling. Stabilize the persistence of the Guide Me toggle across reloads and address a race condition in initial tool derivation.